### PR TITLE
refactor: use Class for ks cache to highly improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,34 @@
-cubic-spline
-===
+# cubic-spline
 
 A slight modification of [Ivan Kuckir's cubic spline implementation](http://blog.ivank.net/interpolation-with-cubic-splines.html), cubic-spline guesses the value of y for any x value on a line. This is helpful for smoothing line graphs.
 
-### installation
+## installation
 
 ```sh
 npm install cubic-spline
 ```
 
-### usage
+## usage
 
 ```js
-var spline = require('cubic-spline');
+var Spline = require('cubic-spline');
 
-var xs = [1,2,3,4,5];
-var ys = [9,3,6,2,4];
+var xs = [1, 2, 3, 4, 5];
+var ys = [9, 3, 6, 2, 4];
+
+// new a Spline object
+const spline = new Spline(xs, ys);
 
 // get Y at arbitrary X
-console.log(spline(1.4, xs, ys));
+console.log(spline.at(1.4));
 
 // interpolate a line at a higher resolution
-for(var i = 0; i < 50; i++) {
-    console.log(spline(i*.1, xs, ys));
+for (var i = 0; i < 50; i++) {
+  console.log(spline.at(i * 0.1));
 }
 ```
 
-### test
+## test
 
 ```sh
 npm test

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ npm install cubic-spline
 ## usage
 
 ```js
-var Spline = require('cubic-spline');
+const Spline = require('cubic-spline');
 
-var xs = [1, 2, 3, 4, 5];
-var ys = [9, 3, 6, 2, 4];
+const xs = [1, 2, 3, 4, 5];
+const ys = [9, 3, 6, 2, 4];
 
 // new a Spline object
 const spline = new Spline(xs, ys);
@@ -23,7 +23,7 @@ const spline = new Spline(xs, ys);
 console.log(spline.at(1.4));
 
 // interpolate a line at a higher resolution
-for (var i = 0; i < 50; i++) {
+for (let i = 0; i < 50; i++) {
   console.log(spline.at(i * 0.1));
 }
 ```

--- a/index.js
+++ b/index.js
@@ -1,62 +1,83 @@
 module.exports = function spline(x, xs, ys) {
-  var ks = xs.map(function(){return 0})
-  ks = getNaturalKs(xs, ys, ks)
+  var ks = xs.map(function() {
+    return 0;
+  });
+  ks = getNaturalKs(xs, ys, ks);
   var i = 1;
-  while(xs[i]<x) i++;
-  var t = (x - xs[i-1]) / (xs[i] - xs[i-1]);
-  var a =  ks[i-1]*(xs[i]-xs[i-1]) - (ys[i]-ys[i-1]);
-  var b = -ks[i]*(xs[i]-xs[i-1]) + (ys[i]-ys[i-1]);
-  var q = (1-t)*ys[i-1] + t*ys[i] + t*(1-t)*(a*(1-t)+b*t);
+  while (xs[i] < x) i++;
+  var t = (x - xs[i - 1]) / (xs[i] - xs[i - 1]);
+  var a = ks[i - 1] * (xs[i] - xs[i - 1]) - (ys[i] - ys[i - 1]);
+  var b = -ks[i] * (xs[i] - xs[i - 1]) + (ys[i] - ys[i - 1]);
+  var q = (1 - t) * ys[i - 1] + t * ys[i] + t * (1 - t) * (a * (1 - t) + b * t);
   return q;
-}
+};
 
-function getNaturalKs (xs, ys, ks) {
-  var n = xs.length-1;
-  var A = zerosMat(n+1, n+2);
-    
-  for(var i=1; i<n; i++)  // rows
-  {
-    A[i][i-1] = 1/(xs[i] - xs[i-1]);
-    A[i][i] = 2 * (1/(xs[i] - xs[i-1]) + 1/(xs[i+1] - xs[i])) ;
-    A[i][i+1] = 1/(xs[i+1] - xs[i]);
-    A[i][n+1] = 3*( (ys[i]-ys[i-1])/((xs[i] - xs[i-1])*(xs[i] - xs[i-1]))  +  (ys[i+1]-ys[i])/ ((xs[i+1] - xs[i])*(xs[i+1] - xs[i])) );
+function getNaturalKs(xs, ys, ks) {
+  var n = xs.length - 1;
+  var A = zerosMat(n + 1, n + 2);
+
+  for (
+    var i = 1;
+    i < n;
+    i++ // rows
+  ) {
+    A[i][i - 1] = 1 / (xs[i] - xs[i - 1]);
+    A[i][i] = 2 * (1 / (xs[i] - xs[i - 1]) + 1 / (xs[i + 1] - xs[i]));
+    A[i][i + 1] = 1 / (xs[i + 1] - xs[i]);
+    A[i][n + 1] =
+      3 *
+      ((ys[i] - ys[i - 1]) / ((xs[i] - xs[i - 1]) * (xs[i] - xs[i - 1])) +
+        (ys[i + 1] - ys[i]) / ((xs[i + 1] - xs[i]) * (xs[i + 1] - xs[i])));
   }
-  
-  A[0][0] = 2/(xs[1] - xs[0]);
-  A[0][1] = 1/(xs[1] - xs[0]);
-  A[0][n+1] = 3 * (ys[1] - ys[0]) / ((xs[1]-xs[0])*(xs[1]-xs[0]));
-  
-  A[n][n-1] = 1/(xs[n] - xs[n-1]);
-  A[n][n] = 2/(xs[n] - xs[n-1]);
-  A[n][n+1] = 3 * (ys[n] - ys[n-1]) / ((xs[n]-xs[n-1])*(xs[n]-xs[n-1]));
-    
-  return solve(A, ks);    
+
+  A[0][0] = 2 / (xs[1] - xs[0]);
+  A[0][1] = 1 / (xs[1] - xs[0]);
+  A[0][n + 1] = (3 * (ys[1] - ys[0])) / ((xs[1] - xs[0]) * (xs[1] - xs[0]));
+
+  A[n][n - 1] = 1 / (xs[n] - xs[n - 1]);
+  A[n][n] = 2 / (xs[n] - xs[n - 1]);
+  A[n][n + 1] =
+    (3 * (ys[n] - ys[n - 1])) / ((xs[n] - xs[n - 1]) * (xs[n] - xs[n - 1]));
+
+  return solve(A, ks);
 }
 
-
-function solve (A, ks) {
+function solve(A, ks) {
   var m = A.length;
-  for(var k=0; k<m; k++)  // column
-  {
+  for (
+    var k = 0;
+    k < m;
+    k++ // column
+  ) {
     // pivot for column
-    var i_max = 0; var vali = Number.NEGATIVE_INFINITY;
-    for(var i=k; i<m; i++) if(A[i][k]>vali) { i_max = i; vali = A[i][k];}
-    swapRows(A, k, i_max);    
-    
+    var i_max = 0;
+    var vali = Number.NEGATIVE_INFINITY;
+    for (var i = k; i < m; i++)
+      if (A[i][k] > vali) {
+        i_max = i;
+        vali = A[i][k];
+      }
+    swapRows(A, k, i_max);
+
     // for all rows below pivot
-    for(var i=k+1; i<m; i++)
-    {
-      for(var j=k+1; j<m+1; j++)
+    for (var i = k + 1; i < m; i++) {
+      for (var j = k + 1; j < m + 1; j++)
         A[i][j] = A[i][j] - A[k][j] * (A[i][k] / A[k][k]);
-        A[i][k] = 0;
+      A[i][k] = 0;
     }
   }
-  for(var i=m-1; i>=0; i--) // rows = columns
-  {
+  for (
+    var i = m - 1;
+    i >= 0;
+    i-- // rows = columns
+  ) {
     var v = A[i][m] / A[i][i];
     ks[i] = v;
-    for(var j=i-1; j>=0; j--) // rows
-    {
+    for (
+      var j = i - 1;
+      j >= 0;
+      j-- // rows
+    ) {
       A[j][m] -= A[j][i] * v;
       A[j][i] = 0;
     }
@@ -64,16 +85,17 @@ function solve (A, ks) {
   return ks;
 }
 
-function zerosMat (r,c) {
-  var A = []; 
-  for(var i=0; i<r; i++) {
-    A.push([]); 
-    for(var j=0; j<c; j++) A[i].push(0);
-  } 
+function zerosMat(r, c) {
+  var A = [];
+  for (var i = 0; i < r; i++) {
+    A.push([]);
+    for (var j = 0; j < c; j++) A[i].push(0);
+  }
   return A;
 }
 
-function swapRows (m, k, l) {
-  var p = m[k]; m[k] = m[l]; m[l] = p;
+function swapRows(m, k, l) {
+  var p = m[k];
+  m[k] = m[l];
+  m[l] = p;
 }
-    

--- a/index.js
+++ b/index.js
@@ -1,58 +1,76 @@
-module.exports = function spline(x, xs, ys) {
-  var ks = xs.map(function() {
-    return 0;
-  });
-  ks = getNaturalKs(xs, ys, ks);
-  var i = 1;
-  while (xs[i] < x) i++;
-  var t = (x - xs[i - 1]) / (xs[i] - xs[i - 1]);
-  var a = ks[i - 1] * (xs[i] - xs[i - 1]) - (ys[i] - ys[i - 1]);
-  var b = -ks[i] * (xs[i] - xs[i - 1]) + (ys[i] - ys[i - 1]);
-  var q = (1 - t) * ys[i - 1] + t * ys[i] + t * (1 - t) * (a * (1 - t) + b * t);
-  return q;
-};
-
-function getNaturalKs(xs, ys, ks) {
-  var n = xs.length - 1;
-  var A = zerosMat(n + 1, n + 2);
-
-  for (
-    var i = 1;
-    i < n;
-    i++ // rows
-  ) {
-    A[i][i - 1] = 1 / (xs[i] - xs[i - 1]);
-    A[i][i] = 2 * (1 / (xs[i] - xs[i - 1]) + 1 / (xs[i + 1] - xs[i]));
-    A[i][i + 1] = 1 / (xs[i + 1] - xs[i]);
-    A[i][n + 1] =
-      3 *
-      ((ys[i] - ys[i - 1]) / ((xs[i] - xs[i - 1]) * (xs[i] - xs[i - 1])) +
-        (ys[i + 1] - ys[i]) / ((xs[i + 1] - xs[i]) * (xs[i + 1] - xs[i])));
+module.exports = class Spline {
+  constructor(xs, ys) {
+    this.xs = xs;
+    this.ys = ys;
+    this.ks = this.getNaturalKs(new Array(this.xs.length).fill(0));
   }
 
-  A[0][0] = 2 / (xs[1] - xs[0]);
-  A[0][1] = 1 / (xs[1] - xs[0]);
-  A[0][n + 1] = (3 * (ys[1] - ys[0])) / ((xs[1] - xs[0]) * (xs[1] - xs[0]));
+  getNaturalKs(ks) {
+    const n = this.xs.length - 1;
+    const A = zerosMat(n + 1, n + 2);
 
-  A[n][n - 1] = 1 / (xs[n] - xs[n - 1]);
-  A[n][n] = 2 / (xs[n] - xs[n - 1]);
-  A[n][n + 1] =
-    (3 * (ys[n] - ys[n - 1])) / ((xs[n] - xs[n - 1]) * (xs[n] - xs[n - 1]));
+    for (
+      let i = 1;
+      i < n;
+      i++ // rows
+    ) {
+      A[i][i - 1] = 1 / (this.xs[i] - this.xs[i - 1]);
+      A[i][i] =
+        2 *
+        (1 / (this.xs[i] - this.xs[i - 1]) + 1 / (this.xs[i + 1] - this.xs[i]));
+      A[i][i + 1] = 1 / (this.xs[i + 1] - this.xs[i]);
+      A[i][n + 1] =
+        3 *
+        ((this.ys[i] - this.ys[i - 1]) /
+          ((this.xs[i] - this.xs[i - 1]) * (this.xs[i] - this.xs[i - 1])) +
+          (this.ys[i + 1] - this.ys[i]) /
+            ((this.xs[i + 1] - this.xs[i]) * (this.xs[i + 1] - this.xs[i])));
+    }
 
-  return solve(A, ks);
-}
+    A[0][0] = 2 / (this.xs[1] - this.xs[0]);
+    A[0][1] = 1 / (this.xs[1] - this.xs[0]);
+    A[0][n + 1] =
+      (3 * (this.ys[1] - this.ys[0])) /
+      ((this.xs[1] - this.xs[0]) * (this.xs[1] - this.xs[0]));
+
+    A[n][n - 1] = 1 / (this.xs[n] - this.xs[n - 1]);
+    A[n][n] = 2 / (this.xs[n] - this.xs[n - 1]);
+    A[n][n + 1] =
+      (3 * (this.ys[n] - this.ys[n - 1])) /
+      ((this.xs[n] - this.xs[n - 1]) * (this.xs[n] - this.xs[n - 1]));
+
+    return solve(A, ks);
+  }
+
+  at(x) {
+    let i = 1;
+    while (this.xs[i] < x) i++;
+    const t = (x - this.xs[i - 1]) / (this.xs[i] - this.xs[i - 1]);
+    const a =
+      this.ks[i - 1] * (this.xs[i] - this.xs[i - 1]) -
+      (this.ys[i] - this.ys[i - 1]);
+    const b =
+      -this.ks[i] * (this.xs[i] - this.xs[i - 1]) +
+      (this.ys[i] - this.ys[i - 1]);
+    const q =
+      (1 - t) * this.ys[i - 1] +
+      t * this.ys[i] +
+      t * (1 - t) * (a * (1 - t) + b * t);
+    return q;
+  }
+};
 
 function solve(A, ks) {
-  var m = A.length;
+  let m = A.length;
   for (
-    var k = 0;
+    let k = 0;
     k < m;
     k++ // column
   ) {
     // pivot for column
-    var i_max = 0;
-    var vali = Number.NEGATIVE_INFINITY;
-    for (var i = k; i < m; i++)
+    let i_max = 0;
+    let vali = Number.NEGATIVE_INFINITY;
+    for (let i = k; i < m; i++)
       if (A[i][k] > vali) {
         i_max = i;
         vali = A[i][k];
@@ -60,21 +78,22 @@ function solve(A, ks) {
     swapRows(A, k, i_max);
 
     // for all rows below pivot
-    for (var i = k + 1; i < m; i++) {
-      for (var j = k + 1; j < m + 1; j++)
+    for (let i = k + 1; i < m; i++) {
+      for (let j = k + 1; j < m + 1; j++) {
         A[i][j] = A[i][j] - A[k][j] * (A[i][k] / A[k][k]);
+      }
       A[i][k] = 0;
     }
   }
   for (
-    var i = m - 1;
+    let i = m - 1;
     i >= 0;
     i-- // rows = columns
   ) {
-    var v = A[i][m] / A[i][i];
+    const v = A[i][m] / A[i][i];
     ks[i] = v;
     for (
-      var j = i - 1;
+      let j = i - 1;
       j >= 0;
       j-- // rows
     ) {
@@ -86,16 +105,16 @@ function solve(A, ks) {
 }
 
 function zerosMat(r, c) {
-  var A = [];
-  for (var i = 0; i < r; i++) {
+  const A = [];
+  for (let i = 0; i < r; i++) {
     A.push([]);
-    for (var j = 0; j < c; j++) A[i].push(0);
+    for (let j = 0; j < c; j++) A[i].push(0);
   }
   return A;
 }
 
 function swapRows(m, k, l) {
-  var p = m[k];
+  let p = m[k];
   m[k] = m[l];
   m[l] = p;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,94 @@
+{
+  "name": "cubic-spline",
+  "version": "1.0.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "deep-equal": {
+      "version": "0.2.2",
+      "resolved": "http://registry.npm.thinkpage.cn/deep-equal/download/deep-equal-0.2.2.tgz",
+      "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0=",
+      "dev": true
+    },
+    "defined": {
+      "version": "0.0.0",
+      "resolved": "http://registry.npm.thinkpage.cn/defined/download/defined-0.0.0.tgz",
+      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "http://registry.npm.thinkpage.cn/glob/download/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "http://registry.npm.thinkpage.cn/inherits/download/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "http://registry.npm.thinkpage.cn/lru-cache/download/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "http://registry.npm.thinkpage.cn/minimatch/download/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "object-inspect": {
+      "version": "0.4.0",
+      "resolved": "http://registry.npm.thinkpage.cn/object-inspect/download/object-inspect-0.4.0.tgz",
+      "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w=",
+      "dev": true
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "http://registry.npm.thinkpage.cn/resumer/download/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3.4"
+      }
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.thinkpage.cn/sigmund/download/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "tape": {
+      "version": "3.6.1",
+      "resolved": "http://registry.npm.thinkpage.cn/tape/download/tape-3.6.1.tgz",
+      "integrity": "sha1-SJPdU+KApfWMDOswwsDrs7zVHh8=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "~0.2.0",
+        "defined": "~0.0.0",
+        "glob": "~3.2.9",
+        "inherits": "~2.0.1",
+        "object-inspect": "~0.4.0",
+        "resumer": "~0.0.0",
+        "through": "~2.3.4"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://registry.npm.thinkpage.cn/through/download/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    }
+  }
+}

--- a/test.js
+++ b/test.js
@@ -1,16 +1,16 @@
 var spline = require('./');
 var test = require('tape');
 
-test('spline', function(t){
-  var xs = [1,2,3,4,5];
-  var ys = [9,3,6,2,4];
+test('spline', function(t) {
+  var xs = [1, 2, 3, 4, 5];
+  var ys = [9, 3, 6, 2, 4];
 
   // get Y at arbitrary X
   t.equal(spline(1.4, xs, ys), 5.586);
 
   // interpolate a line at a higher resolution
-  for(var i = 0; i < 50; i++) {
-    t.equal(typeof spline(i*.1, xs, ys), 'number');
+  for (var i = 0; i < 50; i++) {
+    t.equal(typeof spline(i * 0.1, xs, ys), 'number');
   }
   t.end();
 });

--- a/test.js
+++ b/test.js
@@ -1,16 +1,19 @@
-var spline = require('./');
-var test = require('tape');
+const Spline = require('./');
+const test = require('tape');
 
 test('spline', function(t) {
-  var xs = [1, 2, 3, 4, 5];
-  var ys = [9, 3, 6, 2, 4];
+  const xs = [1, 2, 3, 4, 5];
+  const ys = [9, 3, 6, 2, 4];
+
+  // new a Spline object
+  const spline = new Spline(xs, ys);
 
   // get Y at arbitrary X
-  t.equal(spline(1.4, xs, ys), 5.586);
+  t.equal(spline.at(1.4), 5.586);
 
   // interpolate a line at a higher resolution
   for (var i = 0; i < 50; i++) {
-    t.equal(typeof spline(i * 0.1, xs, ys), 'number');
+    t.equal(typeof spline.at(i * 0.1), 'number');
   }
   t.end();
 });


### PR DESCRIPTION
People do not only use `ks` once for all. Its performance can be improved by avoid repeated calculation of `ks`.