### PR TITLE
improved speed of the .at()-function

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,9 +42,28 @@ module.exports = class Spline {
     return solve(A, ks);
   }
 
+  /**
+   * inspired by https://stackoverflow.com/a/40850313/4417327
+   */
+  getIndexBefore(target) {
+    let low = 0;
+    let high = this.xs.length;
+    let mid = 0;
+    while (low < high) {
+      mid = Math.floor((low + high) / 2);
+      if (this.xs[mid] < target && mid !== low) {
+        low = mid;
+      } else if (this.xs[mid] > target && mid !== high) {
+        high = mid;
+      } else {
+        high = low;
+      }
+    }
+    return low + 1;
+  }
+
   at(x) {
-    let i = 1;
-    while (this.xs[i] < x) i++;
+    let i = this.getIndexBefore(x);
     const t = (x - this.xs[i - 1]) / (this.xs[i] - this.xs[i - 1]);
     const a =
       this.ks[i - 1] * (this.xs[i] - this.xs[i - 1]) -

--- a/test.js
+++ b/test.js
@@ -17,3 +17,47 @@ test('spline', function(t) {
   }
   t.end();
 });
+
+test('speed', function(t) {
+  let arraySizes = [10, 100, 1000, 2000, 4000];
+  let arraySpeed = [];
+  let arrayInitialization = [];
+  let multiplicationFactor = 10; // array.length * multiplicationFactor = number of times the .at()-function is executed on the same array
+  for (let i = 0; i < arraySizes.length; i++) {
+    // generate x-y-set
+    let setX = [];
+    let setY = [];
+    let x = 0;
+    let y = 0;
+    for (let j = 0; j < arraySizes[i]; j++) {
+      x += 0.05;
+      y = Math.sin(x);
+      setX.push(x.toFixed(2));
+      setY.push(y.toFixed(4));
+    }
+    // run cubic-spline-interpolation
+    let initializationStart = new Date();
+    const spline = new Spline(setX, setY);
+    let initializationEnd = new Date();
+    // interpolate spline at 10x resolution
+    let atStart = new Date();
+    for (let j = 0; j < arraySizes[i] * multiplicationFactor; j++) {
+      spline.at(j * 0.05 + 0.01); // create a small offset to the actual data set
+    }
+    let atEnd = new Date();
+    arrayInitialization[i] = initializationEnd - initializationStart;
+    arraySpeed[i] = atEnd - atStart;
+  }
+  // print result
+  console.log(`elements in | times .at() | initialization | execution time`);
+  console.log(`dataset     | is used     | time of spline | of all .at()'s`);
+  console.log(`------------|-------------|----------------|---------------`);
+  for (let i = 0; i < arraySizes.length; i++) {
+    let size = arraySizes[i].toString().padEnd(11);
+    let at = (arraySizes[i] * multiplicationFactor).toString().padStart(11);
+    let initializationTime = arrayInitialization[i].toString().padStart(12);
+    let atTime = arraySpeed[i].toString().padStart(12);
+    console.log(`${size} | ${at} | ${initializationTime}ms | ${atTime}ms`);
+  }
+  t.end();
+});


### PR DESCRIPTION
Hi,

I replaced the `while`-loop with a binary search so that the `.at()`-function is faster on larger datasets.
And I added a test to compare the speed:

```
before:

elements in | times .at() | initialization | execution time
dataset     | is used     | time of spline | of all .at()'s
------------|-------------|----------------|---------------
10          |         100 |            0ms |            0ms
100         |        1000 |            8ms |           11ms
1000        |       10000 |          909ms |          847ms
2000        |       20000 |         7275ms |         3266ms
4000        |       40000 |        56646ms |        14046ms

after:

elements in | times .at() | initialization | execution time
dataset     | is used     | time of spline | of all .at()'s
------------|-------------|----------------|---------------
10          |         100 |            0ms |            1ms
100         |        1000 |           13ms |            5ms
1000        |       10000 |          913ms |           22ms
2000        |       20000 |         7142ms |           53ms
4000        |       40000 |        56850ms |           89ms
```

The binary search itself is inspired by [an similar implementation on Stackoverflow](https://stackoverflow.com/a/40850313/4417327).