### PR TITLE
Fixed getIndexBefore() logic 

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = class Spline {
       mid = Math.floor((low + high) / 2);
       if (this.xs[mid] < target && mid !== low) {
         low = mid;
-      } else if (this.xs[mid] > target && mid !== high) {
+      } else if (this.xs[mid] >= target && mid !== high) {
         high = mid;
       } else {
         high = low;


### PR DESCRIPTION
Hi!
I fixed logic that calculates `i` in `at()` function.

I realized that some values are wrong in the latest 3.0.2, but were good in 3.0.0, so I reverted the changes and figured out that using `getIndexBefore` function was giving different values for `i` than the older version that was using only while loop.