### PR TITLE
Add option for not-a-knot splines

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A slight modification of [Ivan Kuckir's cubic spline implementation](http://blog.ivank.net/interpolation-with-cubic-splines.html), cubic-spline guesses the value of y for any x value on a line. This is helpful for smoothing line graphs.
 
+The [boundary conditions](https://timodenk.com/blog/cubic-spline-interpolation/#boundary-conditions) used for the spline may be of the "natural" (the default) or "not-a-knot" types.
+
 ## installation
 
 ```sh
@@ -26,6 +28,9 @@ console.log(spline.at(1.4));
 for (let i = 0; i < 50; i++) {
   console.log(spline.at(i * 0.1));
 }
+
+// not-a-knot Spline
+const notAKnotSpline = new Spline(xs, ys, { splineType: "not-a-knot" })
 ```
 
 ## test

--- a/index.js
+++ b/index.js
@@ -9,35 +9,37 @@ module.exports = class Spline {
     const n = this.xs.length - 1;
     const A = zerosMat(n + 1, n + 2);
 
+    let deltaX;
+    let deltaY;
+    let deltaXnext = this.xs[1] - this.xs[0];
+    let deltaYnext = this.ys[1] - this.ys[0];
+
     for (
       let i = 1;
       i < n;
       i++ // rows
     ) {
-      A[i][i - 1] = 1 / (this.xs[i] - this.xs[i - 1]);
-      A[i][i] =
-        2 *
-        (1 / (this.xs[i] - this.xs[i - 1]) + 1 / (this.xs[i + 1] - this.xs[i]));
-      A[i][i + 1] = 1 / (this.xs[i + 1] - this.xs[i]);
-      A[i][n + 1] =
-        3 *
-        ((this.ys[i] - this.ys[i - 1]) /
-          ((this.xs[i] - this.xs[i - 1]) * (this.xs[i] - this.xs[i - 1])) +
-          (this.ys[i + 1] - this.ys[i]) /
-            ((this.xs[i + 1] - this.xs[i]) * (this.xs[i + 1] - this.xs[i])));
+      deltaX = deltaXnext;
+      deltaY = deltaYnext;
+      deltaXnext = this.xs[i + 1] - this.xs[i];
+      deltaYnext = this.ys[i + 1] - this.ys[i];
+
+      A[i][i - 1] = 1 / deltaX;
+      A[i][i] = 2 * (1 / deltaX + 1 / deltaXnext);
+      A[i][i + 1] = 1 / deltaXnext;
+      A[i][n + 1] = 3 * (deltaY / deltaX ** 2 + deltaYnext / deltaXnext ** 2);
     }
 
-    A[0][0] = 2 / (this.xs[1] - this.xs[0]);
-    A[0][1] = 1 / (this.xs[1] - this.xs[0]);
-    A[0][n + 1] =
-      (3 * (this.ys[1] - this.ys[0])) /
-      ((this.xs[1] - this.xs[0]) * (this.xs[1] - this.xs[0]));
+    A[n][n - 1] = 1 / deltaXnext;
+    A[n][n] = 2 / deltaXnext;
+    A[n][n + 1] = (3 * deltaYnext) / deltaXnext ** 2;
 
-    A[n][n - 1] = 1 / (this.xs[n] - this.xs[n - 1]);
-    A[n][n] = 2 / (this.xs[n] - this.xs[n - 1]);
-    A[n][n + 1] =
-      (3 * (this.ys[n] - this.ys[n - 1])) /
-      ((this.xs[n] - this.xs[n - 1]) * (this.xs[n] - this.xs[n - 1]));
+    deltaX = this.xs[1] - this.xs[0];
+    deltaY = this.ys[1] - this.ys[0];
+
+    A[0][0] = 2 / deltaX;
+    A[0][1] = 1 / deltaX;
+    A[0][n + 1] = (3 * deltaY) / deltaX ** 2;
 
     return solve(A, ks);
   }

--- a/test.js
+++ b/test.js
@@ -61,3 +61,23 @@ test("speed", function(t) {
   }
   t.end();
 });
+
+test("not-a-knot spline", function(t) {
+  const xs = [0, 1, 2, 3, 4, 5];
+  const ys = [0, -1.5, -2.0, -1.5, 0.0, 2.5];
+
+  // new not-a-knot Spline object
+  const spline = new Spline(xs, ys, { splineType: "not-a-knot" });
+
+  const interpolant = [0.3, 0.5, 1.2, 3.9, 4.1, 4.999];
+  const expected = [-0.555, -0.875, -1.68, -0.195, 0.205, 2.4970005];
+
+  for (var i = 0; i < expected.length; i++) {
+    t.equal(roundToN(spline.at(interpolant[i]) - expected[i], 8), 0);
+  }
+  t.end();
+});
+
+function roundToN(x, n) {
+  return Math.round((x + Number.EPSILON) * Math.pow(10, n)) / Math.pow(10, n);
+}


### PR DESCRIPTION
Adds the option to use 'not-a-knot' boundary conditions in fitting splines, as compared to 'natural' boundary conditions, which remain the default. This is a feature that was personally useful (it is understandable if the maintainers would prefer to keep the package streamlined).

Adds a test for the 'not-a-knot' outputs: the expected values may easily be checked with [`scipy.interpolate.make_interp_spline`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.make_interp_spline.html).

The `getNaturalKs` method has been renamed to `getKs` - this would be a _breaking change_ if users were calling `getNaturalKs` directly (in typical usage it would only be called within the `constructor` method).