### PR TITLE
Add browserifying into a standalone module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ node_modules
 # Compiled output
 index.js
 index.d.ts
+cubic-spline-for-browser.js

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
+    "browserify": "npm run build; browserify index.js -o cubic-spline-for-browser.js --standalone Spline",
     "build": "tsc",
     "build:watch": "tsc --watch",
     "test": "node test.js",
@@ -12,6 +13,7 @@
     "prepublishOnly": "npm run build"
   },
   "files": [
+    "cubic-spline-for-browser.js",
     "index.js",
     "index.d.ts"
   ],
@@ -34,6 +36,7 @@
   },
   "homepage": "https://github.com/morganherlocker/cubic-spline",
   "devDependencies": {
+    "browserify": "^17.0.0",
     "prettier": "2.7.1",
     "tape": "^5.6.1",
     "typescript": "~4.8.4"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:watch": "tsc --watch",
     "test": "node test.js",
     "lint": "prettier **/*.js **/*.json --write",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run browserify"
   },
   "files": [
     "cubic-spline-for-browser.js",


### PR DESCRIPTION
Thank you for your work!
Your library turned to be exactly the one we needed in our project. The only problem was that we use it as a standalone script tag, so I've prepared a version that in browser-compatible.

Hope to see this on npm soon, as I don't want to upload a fork with such a minor change!